### PR TITLE
Handle HTML character codes for square brackets and ampersand

### DIFF
--- a/mister_updater.sh
+++ b/mister_updater.sh
@@ -19,7 +19,7 @@
 # https://github.com/MiSTer-devel/Updater_script_MiSTer
 
 
-
+# Version 4.0.15 - 2021-06-14 - Handle HTML codes for square brackets and ampersand
 # Version 4.0.14 - 2021-03-23 - Fixed a bug in checkAdditionalRepository.
 # Version 4.0.13 - 2021-03-22 - Added XOW scripts to ADDITIONAL_REPOSITORIES; added main branch detection to checkAdditionalRepository.
 # Version 4.0.12 - 2021-03-05 - Updated checkAdditionalRepository in order to reflect a change in GitHub HTML code.
@@ -216,7 +216,7 @@ TO_BE_DELETED_EXTENSION="to_be_deleted"
 
 #========= CODE STARTS HERE =========
 
-UPDATER_VERSION="4.0.14"
+UPDATER_VERSION="4.0.15"
 echo "MiSTer Updater version ${UPDATER_VERSION}"
 echo ""
 

--- a/mister_updater.sh
+++ b/mister_updater.sh
@@ -945,7 +945,7 @@ function checkAdditionalRepository {
 			then
 				#ADDITIONAL_FILE_NAME=$(echo "$ADDITIONAL_FILE_URL" | sed 's/.*\///g' | sed 's/%20/ /g; s/&#39;/'\''/g')
 				#ADDITIONAL_FILE_NAME=$(echo "$ADDITIONAL_FILE_URL" | sed 's/.*\///g' | sed 's/%20/ /g')
-				ADDITIONAL_FILE_NAME=$(echo "$ADDITIONAL_FILE_URL" | sed 's/.*\///g; s/%20/ /g; s/%2C/,/g; s/%5B/[/g; s/%5D/]/g; s/%26/\&/g'; s/   */ /g)
+				ADDITIONAL_FILE_NAME=$(echo "$ADDITIONAL_FILE_URL" | sed 's/.*\///g; s/%20/ /g; s/%2C/,/g; s/%5B/[/g; s/%5D/]/g; s/%26/\&/g')
 				ADDITIONAL_ONLINE_FILE_DATETIME=${ADDITIONAL_FILE_DATETIMES[$CONTENT_INDEX]}
 				if [ -f "$CURRENT_DIR/$ADDITIONAL_FILE_NAME" ]
 				then

--- a/mister_updater.sh
+++ b/mister_updater.sh
@@ -945,7 +945,7 @@ function checkAdditionalRepository {
 			then
 				#ADDITIONAL_FILE_NAME=$(echo "$ADDITIONAL_FILE_URL" | sed 's/.*\///g' | sed 's/%20/ /g; s/&#39;/'\''/g')
 				#ADDITIONAL_FILE_NAME=$(echo "$ADDITIONAL_FILE_URL" | sed 's/.*\///g' | sed 's/%20/ /g')
-				ADDITIONAL_FILE_NAME=$(echo "$ADDITIONAL_FILE_URL" | sed 's/.*\///g; s/%20/ /g; s/%2C/,/g; s/%5B/[/g; s/%5D/]/g; s/%26/\&/g')
+				ADDITIONAL_FILE_NAME=$(echo "$ADDITIONAL_FILE_URL" | sed 's/.*\///g; s/%20/ /g; s/%2C/,/g; s/%5B/[/g; s/%5D/]/g; s/%26/\&/g; s/   */ /g')
 				ADDITIONAL_ONLINE_FILE_DATETIME=${ADDITIONAL_FILE_DATETIMES[$CONTENT_INDEX]}
 				if [ -f "$CURRENT_DIR/${ADDITIONAL_FILE_NAME}" ]
 				then

--- a/mister_updater.sh
+++ b/mister_updater.sh
@@ -945,7 +945,7 @@ function checkAdditionalRepository {
 			then
 				#ADDITIONAL_FILE_NAME=$(echo "$ADDITIONAL_FILE_URL" | sed 's/.*\///g' | sed 's/%20/ /g; s/&#39;/'\''/g')
 				#ADDITIONAL_FILE_NAME=$(echo "$ADDITIONAL_FILE_URL" | sed 's/.*\///g' | sed 's/%20/ /g')
-				ADDITIONAL_FILE_NAME=$(echo "$ADDITIONAL_FILE_URL" | sed 's/.*\///g; s/%20/ /g; s/%2C/,/g; s/%5B/[/g; s/%5D/]/g; s/%26/\&/g')
+				ADDITIONAL_FILE_NAME=$(echo "$ADDITIONAL_FILE_URL" | sed 's/.*\///g; s/%20/ /g; s/%2C/,/g; s/%5B/[/g; s/%5D/]/g; s/%26/\&/g'; s/   */ /g)
 				ADDITIONAL_ONLINE_FILE_DATETIME=${ADDITIONAL_FILE_DATETIMES[$CONTENT_INDEX]}
 				if [ -f "$CURRENT_DIR/$ADDITIONAL_FILE_NAME" ]
 				then

--- a/mister_updater.sh
+++ b/mister_updater.sh
@@ -947,9 +947,9 @@ function checkAdditionalRepository {
 				#ADDITIONAL_FILE_NAME=$(echo "$ADDITIONAL_FILE_URL" | sed 's/.*\///g' | sed 's/%20/ /g')
 				ADDITIONAL_FILE_NAME=$(echo "$ADDITIONAL_FILE_URL" | sed 's/.*\///g; s/%20/ /g; s/%2C/,/g; s/%5B/[/g; s/%5D/]/g; s/%26/\&/g')
 				ADDITIONAL_ONLINE_FILE_DATETIME=${ADDITIONAL_FILE_DATETIMES[$CONTENT_INDEX]}
-				if [ -f "$CURRENT_DIR/$ADDITIONAL_FILE_NAME" ]
+				if [ -f "$CURRENT_DIR/${ADDITIONAL_FILE_NAME}" ]
 				then
-					ADDITIONAL_LOCAL_FILE_DATETIME=$(date -d "$(stat -c %y "$CURRENT_DIR/$ADDITIONAL_FILE_NAME" 2>/dev/null)" -u +"%Y-%m-%dT%H:%M:%SZ")
+					ADDITIONAL_LOCAL_FILE_DATETIME=$(date -d "$(stat -c %y "$CURRENT_DIR/${ADDITIONAL_FILE_NAME}" 2>/dev/null)" -u +"%Y-%m-%dT%H:%M:%SZ")
 				else
 					ADDITIONAL_LOCAL_FILE_DATETIME=""
 				fi
@@ -963,10 +963,10 @@ function checkAdditionalRepository {
 				
 				if [ "$ADDITIONAL_LOCAL_FILE_DATETIME" == "" ] || [[ "$ADDITIONAL_ONLINE_FILE_DATETIME" > "$ADDITIONAL_LOCAL_FILE_DATETIME" ]]
 				then
-					echo "Downloading $ADDITIONAL_FILE_NAME"
+					echo "Downloading ${ADDITIONAL_FILE_NAME}"
 					[ "${SSH_CLIENT}" != "" ] && echo "URL: https://github.com$ADDITIONAL_FILE_URL?raw=true"
 					mv "${CURRENT_DIR}/${ADDITIONAL_FILE_NAME}" "${CURRENT_DIR}/${ADDITIONAL_FILE_NAME}.${TO_BE_DELETED_EXTENSION}" > /dev/null 2>&1
-					if curl $CURL_RETRY $SSL_SECURITY_OPTION $([ "${PARALLEL_UPDATE}" == "true" ] && echo "-sS") -L "https://github.com$ADDITIONAL_FILE_URL?raw=true" -o "$CURRENT_DIR/$ADDITIONAL_FILE_NAME"
+					if curl $CURL_RETRY $SSL_SECURITY_OPTION $([ "${PARALLEL_UPDATE}" == "true" ] && echo "-sS") -L "https://github.com$ADDITIONAL_FILE_URL?raw=true" -o "$CURRENT_DIR/${ADDITIONAL_FILE_NAME}"
 					then
 						rm "${CURRENT_DIR}/${ADDITIONAL_FILE_NAME}.${TO_BE_DELETED_EXTENSION}" > /dev/null 2>&1
 						if [[ "${ADDITIONAL_FILE_NAME}" =~ \.mra ]]

--- a/mister_updater.sh
+++ b/mister_updater.sh
@@ -945,7 +945,7 @@ function checkAdditionalRepository {
 			then
 				#ADDITIONAL_FILE_NAME=$(echo "$ADDITIONAL_FILE_URL" | sed 's/.*\///g' | sed 's/%20/ /g; s/&#39;/'\''/g')
 				#ADDITIONAL_FILE_NAME=$(echo "$ADDITIONAL_FILE_URL" | sed 's/.*\///g' | sed 's/%20/ /g')
-				ADDITIONAL_FILE_NAME=$(echo "$ADDITIONAL_FILE_URL" | sed 's/.*\///g; s/%20/ /g; s/%2C/,/g')
+				ADDITIONAL_FILE_NAME=$(echo "$ADDITIONAL_FILE_URL" | sed 's/.*\///g; s/%20/ /g; s/%2C/,/g; s/%5B/[/g; s/%5D/]/g; s/%26/\&/g')
 				ADDITIONAL_ONLINE_FILE_DATETIME=${ADDITIONAL_FILE_DATETIMES[$CONTENT_INDEX]}
 				if [ -f "$CURRENT_DIR/$ADDITIONAL_FILE_NAME" ]
 				then


### PR DESCRIPTION
Creates a file named something like:
`Arkanoid (Unl. lives) [hb].mra`
instead of
`Arkanoid (Unl. lives) %5Bhb%5D.mra`

or
`Pac & Pal.mra`
instead of
`Pac %26 Pal.mra`

@atrac17 please review and merge (or squash & merge so it becomes merged into a single commit)